### PR TITLE
Fix README reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mac-ansible
 My Mac configuration
 
-❗❗❗**Before running init-script.zsh check the brew-list.txt to see what apps will be installed**❗❗❗
+❗❗❗**Before running init-script.zsh check the app-list.txt to see what apps will be installed**❗❗❗
 
 Run `zsh init-script.zsh` to configure Mac settings and install all apps.


### PR DESCRIPTION
## Summary
- correct README file name in setup instructions

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68404745244c8333bdb935d9df1233ac