### PR TITLE
Update script to disable Spotlight hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mac-ansible
 My Mac configuration
 
-❗❗❗**Before running init-script.zsh check the brew-list.txt to see what apps will be installed**❗❗❗
+❗❗❗**Before running init-script.zsh check the app-list.txt to see what apps will be installed**❗❗❗
 
 Run `zsh init-script.zsh` to configure Mac settings and install all apps.

--- a/init-script.zsh
+++ b/init-script.zsh
@@ -3,6 +3,12 @@ defaults write "com.apple.dock" "persistent-apps" -array; killall Dock
 defaults write com.apple.dock tilesize -int 48; killall Dock
 echo "Dock setup done"
 
+# Disable Spotlight and Finder search hotkeys
+defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 64 '{enabled = 0; value = { parameters = (32, 49, 1048576); type = "standard"; }; }'
+defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 65 '{enabled = 0; value = { parameters = (32, 49, 1572864); type = "standard"; }; }'
+killall SystemUIServer
+echo "Disabled Spotlight and Finder search hotkeys"
+
 # Install Homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 echo "Successfully installed Homebrew"


### PR DESCRIPTION
## Summary
- disable Spotlight and Finder search shortcuts in `init-script.zsh`

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68404745244c8333bdb935d9df1233ac