### PR TITLE
Update init script and disable Spotlight hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mac-ansible
 My Mac configuration
 
-❗❗❗**Before running init-script.zsh check the app-list.txt to see what apps will be installed**❗❗❗
+❗❗❗**Before running init.zsh check the app-list.txt to see what apps will be installed**❗❗❗
 
-Run `zsh init-script.zsh` to configure Mac settings and install all apps.
+Run `zsh init.zsh` to configure Mac settings and install all apps.

--- a/init.zsh
+++ b/init.zsh
@@ -4,8 +4,8 @@ defaults write com.apple.dock tilesize -int 48; killall Dock
 echo "Dock setup done"
 
 # Disable Spotlight and Finder search shortcuts
-/usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:64:enabled false" ~/Library/Preferences/com.apple.symbolichotkeys.plist
-/usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:65:enabled false" ~/Library/Preferences/com.apple.symbolichotkeys.plist
+/usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:64:enabled bool false" ~/Library/Preferences/com.apple.symbolichotkeys.plist
+/usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:65:enabled bool false" ~/Library/Preferences/com.apple.symbolichotkeys.plist
 killall SystemUIServer
 echo "Disabled Spotlight and Finder search hotkeys"
 

--- a/init.zsh
+++ b/init.zsh
@@ -3,6 +3,12 @@ defaults write "com.apple.dock" "persistent-apps" -array; killall Dock
 defaults write com.apple.dock tilesize -int 48; killall Dock
 echo "Dock setup done"
 
+# Disable Spotlight and Finder search shortcuts
+/usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:64:enabled false" ~/Library/Preferences/com.apple.symbolichotkeys.plist
+/usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:65:enabled false" ~/Library/Preferences/com.apple.symbolichotkeys.plist
+killall SystemUIServer
+echo "Disabled Spotlight and Finder search hotkeys"
+
 # Install Homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 echo "Successfully installed Homebrew"

--- a/init.zsh
+++ b/init.zsh
@@ -1,25 +1,55 @@
+# Variables
+PLIST="$HOME/Library/Preferences/com.apple.symbolichotkeys.plist"
+
+# Functions
+disable_hotkey() {
+    local idx="$1"
+    local third_mask="$2"
+
+    echo "Disabling hotkey with index $idx..."
+
+    /usr/libexec/PlistBuddy "$PLIST" -c "Delete :AppleSymbolicHotKeys:$idx" 2>/dev/null || true
+    /usr/libexec/PlistBuddy "$PLIST" -c "Add :AppleSymbolicHotKeys:$idx:\enabled bool false"
+    /usr/libexec/PlistBuddy "$PLIST" -c "Add :AppleSymbolicHotKeys:$idx:value:parameters array"
+    /usr/libexec/PlistBuddy "$PLIST" -c "Add :AppleSymbolicHotKeys:$idx:value:parameters: integer 65535"
+    /usr/libexec/PlistBuddy "$PLIST" -c "Add :AppleSymbolicHotKeys:$idx:value:parameters: integer 49"
+    /usr/libexec/PlistBuddy "$PLIST" -c "Add :AppleSymbolicHotKeys:$idx:value:parameters: integer $third_mask"
+    /usr/libexec/PlistBuddy "$PLIST" -c "Add :AppleSymbolicHotKeys:$idx:value:type string standard"
+
+    /usr/libexec/PlistBuddy "$PLIST" -c "Print :AppleSymbolicHotKeys:$idx"
+}
+
 # Remove all items from Dock and set the icon size to 48
 defaults write "com.apple.dock" "persistent-apps" -array; killall Dock
 defaults write com.apple.dock tilesize -int 48; killall Dock
-echo "Dock setup done"
-
-# Disable Spotlight and Finder search shortcuts
-/usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:64:enabled bool false" ~/Library/Preferences/com.apple.symbolichotkeys.plist
-/usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:65:enabled bool false" ~/Library/Preferences/com.apple.symbolichotkeys.plist
-killall SystemUIServer
-echo "Disabled Spotlight and Finder search hotkeys"
+echo "✅ Dock setup done"
 
 # Install Homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-echo "Successfully installed Homebrew"
+echo "✅ Successfully installed Homebrew"
 
 # Install apps from app-list.txt
 xargs brew install < app-list.txt
-echo "Successfully installed apps"
+echo "✅ Successfully installed apps"
 
 # Add Raycast to login items
 osascript -e 'tell application "System Events" to make login item at end with properties {path:"/Applications/Raycast.app", hidden:true}'
-echo "Added Raycast to login items"
+echo "✅ Added Raycast to login items"
+
+# Disable Spotlight search keyboard shortcut (Index 64, mask 1048576 = Command+Space)
+disable_hotkey 64 1048576
+
+# Disable Finder search window keyboard shortcut (Index 65, mask 1572864 = Command+Option+Space)
+disable_hotkey 65 1572864
+
+# Force cfprefsd to reload the updated plist
+sudo killall cfprefsd
+# Restart SystemUIServer so the menu bar will pick up new settings
+killall SystemUIServer
+# Immediately bind the new hotkey list in memory
+/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
+
+echo "✅ Disabled Spotlight and Finder search hotkeys"
 
 # git config
 git config --global user.name "Stuart van der Lee"
@@ -30,4 +60,4 @@ git config --global pull.rebase false
 git config --global fetch.prune true
 git config --global core.editor "code"
 git config --global init.defaultBranch "main"
-echo "Git config done"
+echo "✅ Git config done"


### PR DESCRIPTION
## Summary
- rename `init-script.zsh` to `init.zsh`
- disable Spotlight and Finder search shortcuts
- update README to reference the new script name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684131b521d08333b6c01d5138831247